### PR TITLE
Add filtering for connect proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+* Documented the filtering required when using Consul connect proxies
+
 ## 0.2.0
 
 * Added custom user agent in the Terraform DNSimple calls (dnsimple/terraform-dnsimple-cts#4)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ task {
   module      = "dnsimple/cts/dnsimple"
 
   condition "services" {
-    names = ["web", "api"]
+    regexp = ".+"
+    filter = "Service.Kind != \"connect-proxy\" and Service.Tags contains \"dnsimple\""
   }
   variable_files = ["/terraform.tfvars"]
 }
@@ -38,6 +39,8 @@ Ensure the services that you have specified have the following parameters added 
 * `meta.record_ttl`:`string` - (Optional) Valid TTL value which will be used for the A record. e.g. `600` - 10 minutes
 
 For an exmaple please refer to [test/web-service.json](test/web-service.json). And [DNSimple Provider](https://www.terraform.io/docs/providers/dnsimple/index.html).
+
+NOTE: In the example above as part of the filtering we exclude all events that are part of a Consul **connect proxy** service, as those events will result in duplication of DNS records.
 
 ## Developing the Provider
 

--- a/test/cts-config.hcl
+++ b/test/cts-config.hcl
@@ -39,7 +39,7 @@ task {
 
   condition "services" {
     regexp = ".+"
-    filter = "Service.Tags contains \"dnsimple\""
+    filter = "Service.Kind != \"connect-proxy\" and Service.Tags contains \"dnsimple\""
   }
   variable_files = ["/consul-terraform-sync/config/terraform.tfvars"]
 }


### PR DESCRIPTION
This PR updates the examples in the README and test configurations with filtering for connect proxies, as connect proxy services result in duplicate DNS records being created for the same service.

Related to #5 